### PR TITLE
Add angular and flot dependencies to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,10 @@
 {
     "name": "angular-flot",
     "main": "angular-flot.js",
+    "dependencies": {
+        "angular": "*",
+        "flot": "*"
+    }
     "version": "0.0.6",
     "authors": [
         "Lorenzo Villani <lvillani@develer.com>"

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "dependencies": {
         "angular": "*",
         "flot": "*"
-    }
+    },
     "version": "0.0.6",
     "authors": [
         "Lorenzo Villani <lvillani@develer.com>"


### PR DESCRIPTION
This allows tools like main-bower-files, which use bower metadata to insert your dependent scripts for you, to know the proper order of scripts.  Without this it was trying to add angular-flot.js before angular.js in the page, resulting in an error on the page.

I left the version requirements loose with a "*".  They could be restricted if desired.
